### PR TITLE
Build info is derived from git without modifying any source code

### DIFF
--- a/DailyGammon/SupportingFiles/BuildInfo.sh
+++ b/DailyGammon/SupportingFiles/BuildInfo.sh
@@ -1,21 +1,36 @@
 #!/bin/sh
 
-#  BuildInfo.sh
-#  Golf
-#
-#  Created by Peter on 08.02.13.
-#
-#buildPlist="${BUILT_PRODUCTS_DIR}/${INFOPLIST_PATH}"
-#buildNumber=$(/usr/libexec/PlistBuddy -c "Print DGbuildNumber" "$buildPlist")
-#buildNumber=$(($buildNumber + 1))
-#/usr/libexec/PlistBuddy -c "Set :DGbuildNumber $buildNumber" "$buildPlist"
-#CFBuildDate=$(date +"%d.%m.%Y %H:%M:%S")
-#/usr/libexec/PlistBuddy -c "Set :DGbuildDate $CFBuildDate" "$buildPlist"
+# Set build number and version in derived data, avoid frequent changes in info.plist.
 
-buildPlist="${BUILT_PRODUCTS_DIR}/${INFOPLIST_PATH}"
-CFBuildDate=$(date +"%d. %B %Y %H:%M:%S")
-#CFBuildDate=$(date +"%d.%m.%Y %H:%M:%S")
-/usr/libexec/PlistBuddy -c "Set :DGBuildDate $CFBuildDate" "$INFOPLIST_FILE"
-buildNumber=$(/usr/libexec/PlistBuddy -c "Print CFBundleVersion" "$INFOPLIST_FILE")
-buildNumber=$(($buildNumber + 1))
-/usr/libexec/PlistBuddy -c "Set :CFBundleVersion $buildNumber" "$INFOPLIST_FILE"
+plist="${TARGET_BUILD_DIR}/${INFOPLIST_PATH}"
+git=`sh /etc/profile; which git`
+
+# Counter of all git commits (across branches) used to ensure a unique build number (App Store Connect requirement)
+
+appBuild=`"$git" rev-list --all --count`
+/usr/libexec/PlistBuddy -c "Set :CFBundleVersion $appBuild" "$plist"
+echo "Updated $plist build number to $appBuild"
+
+# Take the app version from a git tag of the current branch, e.g. "1.4.3"
+
+gitinfo=`"$git" describe --tags --always --long`
+appVersion=`echo ${gitinfo} | awk -F'-' '{print $1}'`
+/usr/libexec/PlistBuddy -c "Set :CFBundleShortVersionString $appVersion" "$plist"
+echo "Updated $plist build version to $appVersion"
+
+# git hash saved in info.plist to identify related commits more easily
+
+gitHash=`"$git" rev-parse --short HEAD`
+/usr/libexec/PlistBuddy -c "Add :DGCommit string $gitHash" "$plist"
+echo -e "DGCommit set to $gitHash"
+
+# Update the versions info in app settings; offset to be adjusted if number of settings changes
+
+settingPlist="${BUILT_PRODUCTS_DIR}/${PRODUCT_NAME}.app/Settings.bundle/Root.plist"
+if [ -f "${settingPlist}" ]
+then
+    /usr/libexec/PlistBuddy -c "set PreferenceSpecifiers:5:DefaultValue $appVersion ($appBuild)" "${settingPlist}"
+    echo -e "Settings.bundle set to $appVersion ($appBuild)"
+else
+    echo -e "Can't find the settings' plist: ${settingPlist}"
+fi


### PR DESCRIPTION
Info.plist of the target build is used when saving CFBundleVersion and CFBundleShortVersionString. The app's version is taken from a git tag, and the build number is the counter of all commits. The settings bundle is updated accordingly.

This way a new version only requires a corresponding tag in git, without any changes of the source code.