### PR TITLE
fixed html query for players with a space in their name

### DIFF
--- a/DailyGammon/Player/Player.m
+++ b/DailyGammon/Player/Player.m
@@ -105,9 +105,9 @@
     self.messageView.layer.cornerRadius = 14.0f;
     self.messageView.layer.borderWidth = 1.0f;
 
-    NSString *searchLink = [NSString stringWithFormat:@"http://dailygammon.com/bg/plist?like=%@&type=name",
+    NSString *searchLinkUnquoted = [NSString stringWithFormat:@"http://dailygammon.com/bg/plist?like=%@&type=name",
                  name];
-
+    NSString *searchLink = [searchLinkUnquoted stringByReplacingOccurrencesOfString:@" " withString:@"+"];
     [self readPlayerArray:searchLink];
  
     [self searchBar:self.suche textDidChange:name];


### PR DESCRIPTION
replace the space with a "+" for the search.
I generally replace all spaces in the URL by "+", can't think of another place with a " " in it.