### PR TITLE
bugfix: pure randomness would change the checkers with every move

### DIFF
--- a/DailyGammon/TopPage/PlayMatch/BoardElements.h
+++ b/DailyGammon/TopPage/PlayMatch/BoardElements.h
@@ -16,11 +16,11 @@ NS_ASSUME_NONNULL_BEGIN
                           name:(NSString *)img
                      withWidth:(float)width
                     withHeight:(float)height
+                forPointRandom:(int)pointNum
 ;
 - (UIImage *)getBarForSchema:(int)schema name:(NSString *)img;
 - (UIImage *)getOffForSchema:(int)schema name:(NSString *)img;
 - (UIImage *)getCubeForSchema:(int)schema name:(NSString *)img;
-- (void)initializeCheckerRandomness;
 
 @end
 

--- a/DailyGammon/TopPage/PlayMatch/BoardElements.h
+++ b/DailyGammon/TopPage/PlayMatch/BoardElements.h
@@ -20,6 +20,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (UIImage *)getBarForSchema:(int)schema name:(NSString *)img;
 - (UIImage *)getOffForSchema:(int)schema name:(NSString *)img;
 - (UIImage *)getCubeForSchema:(int)schema name:(NSString *)img;
+- (void)initializeCheckerRandomness;
 
 @end
 

--- a/DailyGammon/TopPage/PlayMatch/BoardElements.m
+++ b/DailyGammon/TopPage/PlayMatch/BoardElements.m
@@ -21,6 +21,7 @@ int pointsRandomCurrentIndex = 0;
                           name:(NSString *)img
                      withWidth:(float)width
                     withHeight:(float)height
+                forPointRandom:(int)pointNum
 
 {
     UIImage *image = [UIImage imageNamed:@"DeadShot"];
@@ -78,7 +79,8 @@ int pointsRandomCurrentIndex = 0;
                        withCheckerColor:checkerColor
                        withCheckerCount:checkerNumber
                               withWidth:(float)width
-                             withHeight:(float)height];
+                             withHeight:(float)height
+                               forPoint:(int)pointNum];
     }
     return image;
 }
@@ -176,6 +178,7 @@ int pointsRandomCurrentIndex = 0;
                withCheckerCount:(int)checkerCount
                       withWidth:(float)width
                      withHeight:(float)height
+                       forPoint:(int)pointNum
 {
     UIImage *image = [UIImage imageNamed:@"DeadShot"];
     
@@ -214,6 +217,10 @@ int pointsRandomCurrentIndex = 0;
             pointsRandoms[i] = arc4random();
         }
     }
+    
+    // determine the initial random index for this point
+    pointsRandomCurrentIndex = (pointNum*7) % pointsRandomSize;
+    
     for(int i = 0;  i < MIN(5,checkerCount); i++)
     {
         UIImageView *checkerImageView =  [[UIImageView alloc] initWithFrame:CGRectMake(0, 0, width, width)];
@@ -427,11 +434,6 @@ int pointsRandomCurrentIndex = 0;
     UIGraphicsEndImageContext();
 
     return image;
-}
-
-- (void)initializeCheckerRandomness;
-{
-    pointsRandomCurrentIndex = 0;
 }
 
 @end

--- a/DailyGammon/TopPage/PlayMatch/BoardElements.m
+++ b/DailyGammon/TopPage/PlayMatch/BoardElements.m
@@ -11,6 +11,11 @@
 
 @implementation BoardElements
 
+const int pointsRandomSize = 30;
+int pointsRandoms[pointsRandomSize];
+bool isPointsRandomInitialized = false;
+int pointsRandomCurrentIndex = 0;
+
 #pragma mark - methods to decide draw or catalog
 - (UIImage *)getPointForSchema:(int)schema
                           name:(NSString *)img
@@ -201,10 +206,21 @@
         NSString *checkerNameNumber = [NSString stringWithFormat:@"%@_%d",checkerName, checkerNumber++];
         checker = [UIImage imageNamed:checkerNameNumber];
     } while (checker != nil);
+    
+    // initialze permanent random checkers
+    if (!isPointsRandomInitialized) {
+        isPointsRandomInitialized = true;
+        for (int i = 0; i < pointsRandomSize; i++) {
+            pointsRandoms[i] = arc4random();
+        }
+    }
     for(int i = 0;  i < MIN(5,checkerCount); i++)
     {
         UIImageView *checkerImageView =  [[UIImageView alloc] initWithFrame:CGRectMake(0, 0, width, width)];
-        int index =  arc4random() % checkerArray.count;
+        int index =  pointsRandoms[pointsRandomCurrentIndex] % checkerArray.count;
+        pointsRandomCurrentIndex++;
+        if (pointsRandomCurrentIndex >= pointsRandomSize)
+            pointsRandomCurrentIndex = 0;
         checkerImageView.image = checkerArray[index];
         CGRect frame = checkerImageView.frame;
         frame.origin.y = i * width;
@@ -413,5 +429,9 @@
     return image;
 }
 
+- (void)initializeCheckerRandomness;
+{
+    pointsRandomCurrentIndex = 0;
+}
 
 @end

--- a/DailyGammon/TopPage/PlayMatch/MatchTools.m
+++ b/DailyGammon/TopPage/PlayMatch/MatchTools.m
@@ -67,6 +67,8 @@
 
     int x = 0;
     int y = 0;
+    
+    [boardElements initializeCheckerRandomness];
     if([UIDevice currentDevice].userInterfaceIdiom == UIUserInterfaceIdiomPad)
     {
         x = 20;

--- a/DailyGammon/TopPage/PlayMatch/MatchTools.m
+++ b/DailyGammon/TopPage/PlayMatch/MatchTools.m
@@ -68,7 +68,6 @@
     int x = 0;
     int y = 0;
     
-    [boardElements initializeCheckerRandomness];
     if([UIDevice currentDevice].userInterfaceIdiom == UIUserInterfaceIdiomPad)
     {
         x = 20;
@@ -413,7 +412,7 @@
                 {
                     NSString *img = [[images[0] lastPathComponent] stringByDeletingPathExtension];
                     img = [design changeCheckerColor:img forColor:[boardDict objectForKey:@"playerColor"]];
-                    UIImageView *pointView =  [[UIImageView alloc] initWithImage:[boardElements getPointForSchema:schema name:img withWidth:checkerWidth withHeight:pointsHeight]];
+                    UIImageView *pointView =  [[UIImageView alloc] initWithImage:[boardElements getPointForSchema:schema name:img withWidth:checkerWidth withHeight:pointsHeight forPointRandom:i]]; // kha: forPointRandom doesn't need to be the actual point index, suffices if it is the same value for all checkers on the same point
                     pointView.frame = CGRectMake(x, y, checkerWidth, pointsHeight);
                     [boardView addSubview:pointView];
                     x += checkerWidth;
@@ -729,7 +728,7 @@
                 {
                     NSString *img = [[images[0] lastPathComponent] stringByDeletingPathExtension];
                     img = [design changeCheckerColor:img forColor:[boardDict objectForKey:@"playerColor"]];
-                    UIImageView *pointView =  [[UIImageView alloc] initWithImage:[boardElements getPointForSchema:schema name:img withWidth:checkerWidth withHeight:pointsHeight]];
+                    UIImageView *pointView =  [[UIImageView alloc] initWithImage:[boardElements getPointForSchema:schema name:img withWidth:checkerWidth withHeight:pointsHeight forPointRandom:i]]; // kha: again: okay to pass a number that is not the point id, as long as it stays the same for this point
 
                     pointView.frame = CGRectMake(x, y, checkerWidth, pointsHeight);
                     


### PR DESCRIPTION
Not fully perfect - if I move a checker from point n to n+5, the checkers on n+1..n+4 will change their random-index and thus their texture, but it's much less irritating because not the whole board changes textures, just something that feels affected.